### PR TITLE
Ajout des ReactServer dans le renvoi des serveurs de la gateway

### DIFF
--- a/src/DockerServer.js
+++ b/src/DockerServer.js
@@ -3,7 +3,6 @@ const Server = require("./Server");
 
 module.exports = class DockerServer extends Server {
 
-    #gateway;
 
     /**
      * @param {string} name 
@@ -22,16 +21,10 @@ module.exports = class DockerServer extends Server {
         /** @type {"stopped"|"stopping"|"starting"|"started"|"restarting"|"deploying"} */
         this.state = "stopped";
 
-        this.#gateway = gateway;
-
-        this.#gateway.clients.filter((client) => client.metadata.logged).forEach((client) => client.emitEvent("SERVER", { id: this.id, name: this.name, type: this.type, state: this.state }));
-    }
-
-    log(line, date = Date.now()) {
-        const log = { line, date };
-        this.lastLogs.push(log);
-        if (this.lastLogs.length > 500) this.lastLogs.shift();
-        this.#gateway.clients.filter((client) => client.metadata.logged).forEach((client) => client.emitEvent("LOG", { serverId: this.id, logs: [log] }));
+        this._gateway = gateway;
+        if (this._gateway && typeof this._gateway.clients === "object") {
+            this._gateway.clients.filter((client) => client.metadata.logged).forEach((client) => client.emitEvent("SERVER", { id: this.id, name: this.name, type: this.type, state: this.state }));
+        }
     }
 
     listenLogs() {
@@ -49,7 +42,9 @@ module.exports = class DockerServer extends Server {
 
     setState(state) {
         this.state = state;
-        this.#gateway.clients.filter((client) => client.metadata.logged).forEach((client) => client.emitEvent("SERVER_STATE", { serverId: this.id, state: this.state }));
+        if (this._gateway && typeof this._gateway.clients === "object") {
+            this._gateway.clients.filter((client) => client.metadata.logged).forEach((client) => client.emitEvent("SERVER_STATE", { serverId: this.id, state: this.state }));
+        }
     }
 
     async start() {

--- a/src/DockerServer.js
+++ b/src/DockerServer.js
@@ -17,8 +17,6 @@ module.exports = class DockerServer extends Server {
 
         this.container = container;
         this.dockerImage = dockerImage;
-        /** @type {object[]} */
-        this.lastLogs = [];
         /** @type {import("raraph84-lib/src/DockerLogsListener")} */
         this.logsListener = null;
         /** @type {"stopped"|"stopping"|"starting"|"started"|"restarting"|"deploying"} */

--- a/src/NodeJsServer.js
+++ b/src/NodeJsServer.js
@@ -104,7 +104,6 @@ module.exports = class NodeJsServer extends DockerServer {
         if (existsSync(serverDir)) await fs.rename(serverDir, serverDir + "-old");
         await fs.rename(tempDir, serverDir);
 
-        this.lastLogs = [];
         await this.container.start();
 
         await rmrf(serverDir + "-old");

--- a/src/PythonServer.js
+++ b/src/PythonServer.js
@@ -78,7 +78,6 @@ module.exports = class PythonServer extends DockerServer {
         if (existsSync(serverDir)) await fs.rename(serverDir, serverDir + "-old");
         await fs.rename(tempDir, serverDir);
 
-        this.lastLogs = [];
         await this.container.start();
 
         await rmrf(serverDir + "-old");

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -9,7 +9,6 @@ module.exports = class ReactJsServer extends Server {
      * @param {string} name 
      * @param {object} deployment 
      */
-
     constructor(name, deployment) {
         super(name);
 

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -22,7 +22,7 @@ module.exports = class ReactJsServer extends Server {
         if (!this.deployment || this.deploying) return;
         this.deploying = true;
 
-        this.pushLog("Deploying " + this.name + "...");
+        this.log("Deploying " + this.name + "...");
         console.log("Deploying " + this.name + "...");
 
         const serverDir = path.join("/servers", this.name);
@@ -36,7 +36,7 @@ module.exports = class ReactJsServer extends Server {
             throw new Error("Old directory already exists !");
 
         try {
-            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, (line) => this.pushLog(line));
+            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, (line) => this.log(line));
         } catch (error) {
             await this.onDeployError(error);
             return;
@@ -52,10 +52,10 @@ module.exports = class ReactJsServer extends Server {
                 if (existsSync(path.join(serverDir, "package.json")) && existsSync(path.join(serverDir, "node_modules"))
                     && await fs.readFile(path.join(tempDir, "package.json"), "utf8") === await fs.readFile(path.join(serverDir, "package.json"), "utf8")) {
 
-                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`, (line) => this.pushLog(line));
+                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`, (line) => this.log(line));
 
                 } else {
-                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`, (line) => this.pushLog(line));
+                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`, (line) => this.log(line));
                 }
 
             } catch (error) {
@@ -68,7 +68,7 @@ module.exports = class ReactJsServer extends Server {
             if (existsSync(path.join(serverDir, ignoredFile))) {
                 await rmrf(path.join(tempDir, ignoredFile));
                 try {
-                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, (line) => this.pushLog(line));
+                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, (line) => this.log(line));
                 } catch (error) {
                     await this.onDeployError(error);
                     return;
@@ -79,7 +79,7 @@ module.exports = class ReactJsServer extends Server {
         await rmrf(path.join(tempDir, "build"));
 
         try {
-            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`, (line) => this.pushLog(line));
+            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`, (line) => this.log(line));
         } catch (error) {
             await this.onDeployError(error);
             return;
@@ -93,7 +93,7 @@ module.exports = class ReactJsServer extends Server {
         await rmrf(serverDir + "-old");
 
         this.deploying = false;
-        this.pushLog("Deployed " + this.name);
+        this.log("Deployed " + this.name);
         console.log("Deployed " + this.name);
     }
 }

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -20,42 +20,33 @@ module.exports = class ReactJsServer extends Server {
         if (!this.deployment || this.deploying) return;
         this.deploying = true;
         this.lastLogs = [];
-        const pushLog = (line) => {
-            if (line && typeof line === "string") this.lastLogs.push(line);
-        };
+        this.pushLog("Deploying " + this.name + "...");
         console.log("Deploying " + this.name + "...");
-        pushLog("Deploying " + this.name + "...");
         const serverDir = path.join("/servers", this.name);
         const tempDir = serverDir + "-temp";
         const hostTempDir = path.join(process.env.HOST_SERVERS_DIR_PATH, this.name + "-temp");
         const rmrf = async (dir) => { if (existsSync(dir)) await fs.rm(dir, { recursive: true }); };
-        const onError = async (error) => {
-            this.deploying = false;
-            pushLog("Error deploying " + this.name + " : " + error);
-            console.log("Error deploying " + this.name + " :", error);
-        };
         await rmrf(tempDir);
         if (existsSync(serverDir + "-old"))
             throw new Error("Old directory already exists !");
         try {
-            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, pushLog);
+            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, (line) => this.pushLog(line));
         } catch (error) {
-            await onError(error);
+            await this.onDeployError(error);
             return;
         }
         await rmrf(path.join(tempDir, ".git"));
         if (existsSync(path.join(tempDir, "package.json"))) {
             await rmrf(path.join(tempDir, "node_modules"));
-
             try {
                 if (existsSync(path.join(serverDir, "package.json")) && existsSync(path.join(serverDir, "node_modules"))
                     && await fs.readFile(path.join(tempDir, "package.json"), "utf8") === await fs.readFile(path.join(serverDir, "package.json"), "utf8")) {
-                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`, pushLog);
+                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`, (line) => this.pushLog(line));
                 } else {
-                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`, pushLog);
+                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`, (line) => this.pushLog(line));
                 }
             } catch (error) {
-                await onError(error);
+                await this.onDeployError(error);
                 return;
             }
         }
@@ -63,18 +54,18 @@ module.exports = class ReactJsServer extends Server {
             if (existsSync(path.join(serverDir, ignoredFile))) {
                 await rmrf(path.join(tempDir, ignoredFile));
                 try {
-                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, pushLog);
+                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, (line) => this.pushLog(line));
                 } catch (error) {
-                    await onError(error);
+                    await this.onDeployError(error);
                     return;
                 }
             }
         }
         await rmrf(path.join(tempDir, "build"));
         try {
-            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`, pushLog);
+            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`, (line) => this.pushLog(line));
         } catch (error) {
-            await onError(error);
+            await this.onDeployError(error);
             return;
         }
         await rmrf(path.join(tempDir, "www"));
@@ -83,7 +74,7 @@ module.exports = class ReactJsServer extends Server {
         await fs.rename(tempDir, serverDir);
         await rmrf(serverDir + "-old");
         this.deploying = false;
-        pushLog("Deployed " + this.name);
+        this.pushLog("Deployed " + this.name);
         console.log("Deployed " + this.name);
     }
 }

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -9,90 +9,82 @@ module.exports = class ReactJsServer extends Server {
      * @param {string} name 
      * @param {object} deployment 
      */
+
     constructor(name, deployment) {
-
         super(name);
-
         this.type = "reactjs";
         this.deployment = deployment;
+        this.lastLogs = [];
     }
 
     async deploy() {
-
         if (!this.deployment || this.deploying) return;
         this.deploying = true;
-
+        this.lastLogs = [];
+        const pushLog = (line) => {
+            if (line && typeof line === "string") this.lastLogs.push(line);
+        };
         console.log("Deploying " + this.name + "...");
-
+        pushLog("Deploying " + this.name + "...");
         const serverDir = path.join("/servers", this.name);
         const tempDir = serverDir + "-temp";
         const hostTempDir = path.join(process.env.HOST_SERVERS_DIR_PATH, this.name + "-temp");
-
         const rmrf = async (dir) => { if (existsSync(dir)) await fs.rm(dir, { recursive: true }); };
-
         const onError = async (error) => {
             this.deploying = false;
+            pushLog("Error deploying " + this.name + " : " + error);
             console.log("Error deploying " + this.name + " :", error);
         };
-
         await rmrf(tempDir);
         if (existsSync(serverDir + "-old"))
             throw new Error("Old directory already exists !");
-
         try {
-            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`);
+            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, pushLog);
         } catch (error) {
             await onError(error);
             return;
         }
-
         await rmrf(path.join(tempDir, ".git"));
-
         if (existsSync(path.join(tempDir, "package.json"))) {
-
             await rmrf(path.join(tempDir, "node_modules"));
 
             try {
                 if (existsSync(path.join(serverDir, "package.json")) && existsSync(path.join(serverDir, "node_modules"))
-                    && await fs.readFile(path.join(tempDir, "package.json"), "utf8") === await fs.readFile(path.join(serverDir, "package.json"), "utf8"))
-                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`);
-                else
-                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`);
+                    && await fs.readFile(path.join(tempDir, "package.json"), "utf8") === await fs.readFile(path.join(serverDir, "package.json"), "utf8")) {
+                    await runCommand(`cp -r ${path.join(serverDir, "node_modules")} ${tempDir}`, pushLog);
+                } else {
+                    await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -e HOME=/tmp -w /server ${this.deployment.dockerImage} npm install${!this.deployment.installDev ? " --omit=dev" : ""}`, pushLog);
+                }
             } catch (error) {
                 await onError(error);
                 return;
             }
         }
-
         for (const ignoredFile of (this.deployment.ignoredFiles || [])) {
             if (existsSync(path.join(serverDir, ignoredFile))) {
                 await rmrf(path.join(tempDir, ignoredFile));
                 try {
-                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`);
+                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, pushLog);
                 } catch (error) {
                     await onError(error);
                     return;
                 }
             }
         }
-
         await rmrf(path.join(tempDir, "build"));
-
         try {
-            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`);
+            await runCommand(`docker run --rm -i --name ${this.name}-Deploy -u ${process.getuid()}:${process.getgid()} -v ${hostTempDir}:/server -w /server ${this.deployment.dockerImage} npm run build`, pushLog);
         } catch (error) {
             await onError(error);
             return;
         }
-
         await rmrf(path.join(tempDir, "www"));
         await fs.rename(path.join(tempDir, "build"), path.join(tempDir, "www"));
-
         if (existsSync(serverDir)) await fs.rename(serverDir, serverDir + "-old");
         await fs.rename(tempDir, serverDir);
         await rmrf(serverDir + "-old");
-
         this.deploying = false;
+        pushLog("Deployed " + this.name);
         console.log("Deployed " + this.name);
     }
 }

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -22,7 +22,6 @@ module.exports = class ReactJsServer extends Server {
         if (!this.deployment || this.deploying) return;
         this.deploying = true;
 
-        this.lastLogs = [];
         this.pushLog("Deploying " + this.name + "...");
         console.log("Deploying " + this.name + "...");
 

--- a/src/ReactJsServer.js
+++ b/src/ReactJsServer.js
@@ -14,7 +14,6 @@ module.exports = class ReactJsServer extends Server {
         super(name);
         this.type = "reactjs";
         this.deployment = deployment;
-        this.lastLogs = [];
     }
 
     async deploy() {

--- a/src/Server.js
+++ b/src/Server.js
@@ -19,6 +19,8 @@ module.exports = class Server {
         this.name = name;
         this.type = "unknown";
         this.deploying = false;
+        /** @type {object[]} */
+        this.lastLogs = [];
 
         Server.servers.push(this);
     }

--- a/src/Server.js
+++ b/src/Server.js
@@ -26,7 +26,7 @@ module.exports = class Server {
     }
 
     /**
-     * Ajoute une ligne de log à lastLogs
+     * Adds a log line to the server's logs
      * @param {string} line
      */
     pushLog(line) {
@@ -34,7 +34,7 @@ module.exports = class Server {
     }
 
     /**
-     * Gestion d'erreur (des déploiements)
+     * Handles deployment errors
      * @param {string|Error} error
      */
     async onDeployError(error) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -26,6 +26,24 @@ module.exports = class Server {
     }
 
     /**
+     * Ajoute une ligne de log à lastLogs
+     * @param {string} line
+     */
+    pushLog(line) {
+        if (line && typeof line === "string") this.lastLogs.push(line);
+    }
+
+    /**
+     * Gestion d'erreur (des déploiements)
+     * @param {string|Error} error
+     */
+    async onDeployError(error) {
+        this.deploying = false;
+        this.pushLog(`Error deploying ${this.name} : ${error}`);
+        console.log(`Error deploying ${this.name} :`, error);
+    }
+
+    /**
      * @param {import("raraph84-lib/src/WebSocketServer")} gateway 
      */
     static async init(gateway) {

--- a/src/WebsiteServer.js
+++ b/src/WebsiteServer.js
@@ -23,7 +23,7 @@ module.exports = class WebsiteServer extends Server {
 
         this.deploying = true;
 
-        this.pushLog("Deploying " + this.name + "...");
+        this.log("Deploying " + this.name + "...");
         console.log("Deploying " + this.name + "...");
 
         const serverDir = path.join("/servers", this.name);
@@ -35,7 +35,7 @@ module.exports = class WebsiteServer extends Server {
             throw new Error("Old directory already exists !");
 
         try {
-            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, (line) => this.pushLog(line));
+            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, (line) => this.log(line));
         } catch (error) {
             await this.onDeployError(error);
             return;
@@ -47,7 +47,7 @@ module.exports = class WebsiteServer extends Server {
             if (existsSync(path.join(serverDir, ignoredFile))) {
                 await rmrf(path.join(tempDir, ignoredFile));
                 try {
-                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, (line) => this.pushLog(line));
+                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, (line) => this.log(line));
                 } catch (error) {
                     await this.onDeployError(error);
                     return;
@@ -60,7 +60,7 @@ module.exports = class WebsiteServer extends Server {
         await rmrf(serverDir + "-old");
 
         this.deploying = false;
-        this.pushLog("Deployed " + this.name);
+        this.log("Deployed " + this.name);
         console.log("Deployed " + this.name);
     }
 }

--- a/src/WebsiteServer.js
+++ b/src/WebsiteServer.js
@@ -22,7 +22,6 @@ module.exports = class WebsiteServer extends Server {
         if (!this.deployment || this.deploying) return;
 
         this.deploying = true;
-        this.lastLogs = [];
 
         this.pushLog("Deploying " + this.name + "...");
         console.log("Deploying " + this.name + "...");

--- a/src/WebsiteServer.js
+++ b/src/WebsiteServer.js
@@ -14,7 +14,6 @@ module.exports = class WebsiteServer extends Server {
         super(name);
         this.type = "website";
         this.deployment = deployment;
-        this.lastLogs = [];
     }
 
     async deploy() {

--- a/src/WebsiteServer.js
+++ b/src/WebsiteServer.js
@@ -9,61 +9,57 @@ module.exports = class WebsiteServer extends Server {
      * @param {string} name 
      * @param {object} deployment 
      */
+
     constructor(name, deployment) {
-
         super(name);
-
         this.type = "website";
         this.deployment = deployment;
+        this.lastLogs = [];
     }
 
     async deploy() {
-
         if (!this.deployment || this.deploying) return;
         this.deploying = true;
-
+        this.lastLogs = [];
+        const pushLog = (line) => {
+            if (line && typeof line === "string") this.lastLogs.push(line);
+        };
         console.log("Deploying " + this.name + "...");
-
+        pushLog("Deploying " + this.name + "...");
         const serverDir = path.join("/servers", this.name);
         const tempDir = serverDir + "-temp";
-
         const rmrf = async (dir) => { if (existsSync(dir)) await fs.rm(dir, { recursive: true }); };
-
         const onError = async (error) => {
             this.deploying = false;
+            pushLog("Error deploying " + this.name + " : " + error);
             console.log("Error deploying " + this.name + " :", error);
         };
-
         await rmrf(tempDir);
         if (existsSync(serverDir + "-old"))
             throw new Error("Old directory already exists !");
-
         try {
-            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`);
+            await runCommand(`git clone https://${this.deployment.githubAuth || "none"}@github.com/${this.deployment.githubRepo} -b ${this.deployment.githubBranch} ${tempDir}`, pushLog);
         } catch (error) {
             await onError(error);
             return;
         }
-
         await rmrf(path.join(tempDir, ".git"));
-
         for (const ignoredFile of (this.deployment.ignoredFiles || [])) {
             if (existsSync(path.join(serverDir, ignoredFile))) {
                 await rmrf(path.join(tempDir, ignoredFile));
                 try {
-                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`);
+                    await runCommand(`cp -r ${path.join(serverDir, ignoredFile)} ${tempDir}`, pushLog);
                 } catch (error) {
                     await onError(error);
                     return;
                 }
             }
         }
-
         if (existsSync(serverDir)) await fs.rename(serverDir, serverDir + "-old");
         await fs.rename(tempDir, serverDir);
         await rmrf(serverDir + "-old");
-
         this.deploying = false;
+        pushLog("Deployed " + this.name);
         console.log("Deployed " + this.name);
     }
 }

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -53,10 +53,8 @@ module.exports.start = async () => {
             client.emitEvent("LOGGED");
 
             Server.servers.forEach((server) => {
-                if (server instanceof DockerServer || server instanceof ReactJsServer || server instanceof WebsiteServer) {
-                    client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type, state: server.state });
-                    client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
-                }
+                client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type, state: server.state });
+                client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
             });
             return;
         }

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -119,19 +119,6 @@ module.exports.start = async () => {
         } else {
             client.close("This server type is not supported");
         }
-
-        try {
-            if (command === "START_SERVER")
-                server.start();
-            else if (command === "STOP_SERVER")
-                server.stop();
-            else if (command === "RESTART_SERVER")
-                server.restart();
-            else if (command === "DEPLOY_SERVER")
-                server.deploy();
-        } catch (error) {
-            client.close(error);
-        }
     });
 
     console.log("Lancement du serveur WebSocket...");

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -1,6 +1,8 @@
 const { getConfig, WebSocketServer } = require("raraph84-lib");
 const Server = require("./Server");
 const DockerServer = require("./DockerServer");
+const ReactJsServer = require("./ReactJsServer");
+const WebsiteServer = require("./WebsiteServer");
 const config = getConfig(__dirname + "/..");
 
 /** @param {import("raraph84-lib/src/WebSocketServer")} */
@@ -54,7 +56,7 @@ module.exports.start = async () => {
                 if (server instanceof DockerServer) {
                     client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type, state: server.state });
                     client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
-                } else if (server.constructor.name === "ReactJsServer") {
+                } else if (server instanceof ReactJsServer || server instanceof WebsiteServer) {
                     client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type });
                 }
             });
@@ -106,7 +108,7 @@ module.exports.start = async () => {
             } catch (error) {
                 client.close(error);
             }
-        } else if (server.constructor.name === "ReactJsServer") {
+        } else if (server instanceof ReactJsServer || server instanceof WebsiteServer) {
             if (command === "DEPLOY_SERVER") {
                 try {
                     server.deploy();
@@ -114,7 +116,7 @@ module.exports.start = async () => {
                     client.close(error);
                 }
             } else {
-                client.close("Only DEPLOY_SERVER is allowed for ReactJsServer");
+                client.close("Only DEPLOY_SERVER is allowed for ReactJsServer and WebsiteServer");
             }
         } else {
             client.close("This server type is not supported");

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -58,6 +58,9 @@ module.exports.start = async () => {
                     client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
                 } else if (server instanceof ReactJsServer || server instanceof WebsiteServer) {
                     client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type });
+                    if (server instanceof ReactJsServer) {
+                        client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
+                    }
                 }
             });
             return;

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -53,14 +53,9 @@ module.exports.start = async () => {
             client.emitEvent("LOGGED");
 
             Server.servers.forEach((server) => {
-                if (server instanceof DockerServer) {
+                if (server instanceof DockerServer || server instanceof ReactJsServer || server instanceof WebsiteServer) {
                     client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type, state: server.state });
                     client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
-                } else if (server instanceof ReactJsServer || server instanceof WebsiteServer) {
-                    client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type });
-                    if (server instanceof ReactJsServer) {
-                        client.emitEvent("LOG", { serverId: server.id, logs: server.lastLogs });
-                    }
                 }
             });
             return;

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -50,7 +50,6 @@ module.exports.start = async () => {
             client.metadata.logged = true;
             client.emitEvent("LOGGED");
 
-            // Envoie les serveurs Docker et ReactJsServer
             Server.servers.forEach((server) => {
                 if (server instanceof DockerServer) {
                     client.emitEvent("SERVER", { id: server.id, name: server.name, type: server.type, state: server.state });
@@ -94,8 +93,6 @@ module.exports.start = async () => {
             return;
         }
 
-
-        // Gestion des commandes selon le type de serveur
         if (server instanceof DockerServer) {
             try {
                 if (command === "START_SERVER")


### PR DESCRIPTION
Ajout des ReactJsServer dans la liste des serveurs renvoyés dans la gateway.
Pour les commandes, il n'y a que DEPLOY_SERVER qui soit autorisée.

Je n'ai pas créé de classe parent équivalent à DockerServer vu qu'il y avait juste les ReactServer qui sont concernés.

_(à tester sur machine)_